### PR TITLE
Migrate backend to 2025 Scoring Model

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {

--- a/common/types/ws_types.ts
+++ b/common/types/ws_types.ts
@@ -1,5 +1,5 @@
 import { EventInfo, MatchSound, PartialAlliance, PartialMatch, PartialTeam, RankingEntry, ToteKey } from '.'
-import { Match, Match_AllianceResults, PlayoffAlliance, Team, Tote } from '@prisma/client'
+import { Match, Match_AllianceResults, PlayoffAlliance, Team } from '@prisma/client'
 
 export interface ServerToClientEvents {
     match(data: Match): void
@@ -34,7 +34,7 @@ export interface ClientToServerEvents {
     partialTeam(data: PartialTeam): void
     partialEvent(data: Partial<EventInfo>): void
     partialAlliance(data: PartialAlliance): void
-    toteData(matchid: string, tote: ToteKey, data: Partial<Tote>): void
+    toteData(matchid: string, tote: ToteKey, data: Partial<unknown>): void
     zoneData(matchid: string, isRed: boolean, data: Partial<Match_AllianceResults>): void
 
     newTeam(data: Team): void

--- a/common/utils/blanks.ts
+++ b/common/utils/blanks.ts
@@ -1,4 +1,4 @@
-import { Match, Match_AllianceResults, Match_Results, Team, Tote } from '@prisma/client'
+import { Match, Match_AllianceResults, Match_Results, Team } from '@prisma/client'
 import { EventInfo } from '../types'
 
 export function getBlankAllianceScoreBreakdown(): Match_AllianceResults {
@@ -6,37 +6,25 @@ export function getBlankAllianceScoreBreakdown(): Match_AllianceResults {
         card_robot1: 'none',
         card_robot2: 'none',
         card_robot3: 'none',
-        zone_bunnies: 0,
-        zone_balloons_own: 0,
-        zone_balloons_opp: 0,
-        foul_points: 0
+        feeding_station_auto: 0,
+        feeding_station_tele: 0,
+        grass_auto: 0,
+        grass_tele: 0,
+        endgame_bunnies: 0,
+        total_hits: 0,
+        auto_park_robot1: false,
+        auto_park_robot2: false,
+        auto_park_robot3: false,
+        foul_points: 0,
     }
 }
 
 export function getBlankMatchScoreBreakdown(): Match_Results {
     return {
-        corral_empty: false,
-        totes: {
-            tote1: getBlankTote(),
-            tote2: getBlankTote(),
-            tote3: getBlankTote(),
-            tote4: getBlankTote(),
-            tote5: getBlankTote(),
-            tote6: getBlankTote(),
-            tote7: getBlankTote(),
-            tote8: getBlankTote(),
-            tote9: getBlankTote(),
-            tote10: getBlankTote(),
-            tote11: getBlankTote(),
-            tote12: getBlankTote()
-        },
+        cabbages_in_patch: false,
         red: getBlankAllianceScoreBreakdown(),
         blue: getBlankAllianceScoreBreakdown()
     }
-}
-
-export function getBlankTote(): Required<Tote> {
-    return { red_balloons: 0, blue_balloons: 0, bunnies: 0 }
 }
 
 export function getBlankTeam(): Required<Team> {

--- a/common/utils/blanks.ts
+++ b/common/utils/blanks.ts
@@ -15,7 +15,7 @@ export function getBlankAllianceScoreBreakdown(): Match_AllianceResults {
         auto_park_robot1: false,
         auto_park_robot2: false,
         auto_park_robot3: false,
-        foul_points: 0,
+        foul_points: 0
     }
 }
 

--- a/common/utils/scores.ts
+++ b/common/utils/scores.ts
@@ -32,21 +32,20 @@ export function calculatePointsBreakdown(breakdown: Match_Results): { red: Point
     if (breakdown == null) {
         return points
     }
-    for (const alliance_data of [{ points: points.red, breakdown: breakdown.red }, { points: points.blue, breakdown: breakdown.blue }]) {
-        const { points, breakdown:alliance_breakdown } = alliance_data
+    for (const alliance_data of [
+        { points: points.red, breakdown: breakdown.red },
+        { points: points.blue, breakdown: breakdown.blue }
+    ]) {
+        const { points, breakdown: alliance_breakdown } = alliance_data
         points.auto_carrots += 5 * alliance_breakdown.feeding_station_auto // 5 points per carrot in feeding station
-        points.auto_carrots += 1 * alliance_breakdown.grass_auto           // 1 point per carrot in the grass
+        points.auto_carrots += 1 * alliance_breakdown.grass_auto // 1 point per carrot in the grass
 
-        points.auto_park += 5 * countTrue(
-            alliance_breakdown.auto_park_robot1,
-            alliance_breakdown.auto_park_robot2,
-            alliance_breakdown.auto_park_robot3
-        ) // 5 points for robot partially in the carrot patch at end of auto
+        points.auto_park += 5 * countTrue(alliance_breakdown.auto_park_robot1, alliance_breakdown.auto_park_robot2, alliance_breakdown.auto_park_robot3) // 5 points for robot partially in the carrot patch at end of auto
 
         points.tele_carrots += 10 * alliance_breakdown.feeding_station_tele
         points.tele_carrots += 1 * alliance_breakdown.grass_tele
         points.tele_hits += 5 * alliance_breakdown.total_hits
-        
+
         points.tele_bunnies += 10 * alliance_breakdown.endgame_bunnies
         points.foul = alliance_breakdown.foul_points
         if (breakdown.cabbages_in_patch) {

--- a/common/utils/scores.ts
+++ b/common/utils/scores.ts
@@ -2,19 +2,23 @@ import { Match, Match_Results } from '@prisma/client'
 import { ToteKey } from '../types'
 
 export type PointsBreakdown = {
-    tote_balloons: number
-    empty_corral: number
-    low_zone_bunny: number
-    low_zone_balloon: number
+    auto_carrots: number
+    auto_park: number
+    coopertition: number
+    tele_carrots: number
+    tele_bunnies: number
+    tele_hits: number
     foul: number
 }
 
 function getBlankPointsBreakdown(): PointsBreakdown {
     return {
-        tote_balloons: 0,
-        empty_corral: 0,
-        low_zone_bunny: 0,
-        low_zone_balloon: 0,
+        auto_carrots: 0,
+        auto_park: 0,
+        coopertition: 0,
+        tele_carrots: 0,
+        tele_bunnies: 0,
+        tele_hits: 0,
         foul: 0
     }
 }
@@ -28,27 +32,26 @@ export function calculatePointsBreakdown(breakdown: Match_Results): { red: Point
     if (breakdown == null) {
         return points
     }
-    points.red.low_zone_balloon += 1 * breakdown.red.zone_balloons_own // 1 point per balloon in low zone
-    points.red.low_zone_balloon += 1 * breakdown.blue.zone_balloons_opp // 1 point per balloon in low zone
+    for (const alliance_data of [{ points: points.red, breakdown: breakdown.red }, { points: points.blue, breakdown: breakdown.blue }]) {
+        const { points, breakdown:alliance_breakdown } = alliance_data
+        points.auto_carrots += 5 * alliance_breakdown.feeding_station_auto // 5 points per carrot in feeding station
+        points.auto_carrots += 1 * alliance_breakdown.grass_auto           // 1 point per carrot in the grass
 
-    points.blue.low_zone_balloon += 1 * breakdown.blue.zone_balloons_own // 1 point per balloon in low zone
-    points.blue.low_zone_balloon += 1 * breakdown.red.zone_balloons_opp // 1 point per balloon in low zone
+        points.auto_park += 5 * countTrue(
+            alliance_breakdown.auto_park_robot1,
+            alliance_breakdown.auto_park_robot2,
+            alliance_breakdown.auto_park_robot3
+        ) // 5 points for robot partially in the carrot patch at end of auto
 
-    points.red.low_zone_bunny += 6 * breakdown.red.zone_bunnies // 6 points per bunny in low zone
-    points.blue.low_zone_bunny += 6 * breakdown.blue.zone_bunnies // 6 points per bunny in low zone
-
-    for (const id in breakdown.totes) {
-        const tote = breakdown.totes[id as ToteKey]
-        const multiplier = 3 * 2 ** tote.bunnies // 3x2^B points per balloon in tote with B bunnies
-        points.red.tote_balloons += tote.red_balloons * multiplier
-        points.blue.tote_balloons += tote.blue_balloons * multiplier
-    }
-    points.blue.foul = breakdown.blue.foul_points
-    points.red.foul = breakdown.red.foul_points
-    if (breakdown.corral_empty) {
-        // 20 point coopertition bonus
-        points.red.empty_corral = 20
-        points.blue.empty_corral = 20
+        points.tele_carrots += 10 * alliance_breakdown.feeding_station_tele
+        points.tele_carrots += 1 * alliance_breakdown.grass_tele
+        points.tele_hits += 5 * alliance_breakdown.total_hits
+        
+        points.tele_bunnies += 10 * alliance_breakdown.endgame_bunnies
+        points.foul = alliance_breakdown.foul_points
+        if (breakdown.cabbages_in_patch) {
+            points.coopertition = 20
+        }
     }
 
     return points

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,41 +57,29 @@ model Match {
   @@unique([stage_index, type])
 }
 
-type Totes {
-  tote1  Tote
-  tote2  Tote
-  tote3  Tote
-  tote4  Tote
-  tote5  Tote
-  tote6  Tote
-  tote7  Tote
-  tote8  Tote
-  tote9  Tote
-  tote10 Tote
-  tote11 Tote
-  tote12 Tote
-}
-
-type Tote {
-  red_balloons  Int // The number of red balloons in the tote
-  blue_balloons Int // The number of blue balloons in the tote
-  bunnies       Int // The number of bunnies in the tote at the end of auto
-}
-
 type Match_Results {
   red          Match_AllianceResults
   blue         Match_AllianceResults
-  totes        Totes
-  corral_empty Boolean
+  cabbages_in_patch Boolean // Whether both cabages are in the carrot patch at the end of the match (coopertition)
 }
 
 type Match_AllianceResults {
   card_robot1       Card // The card for the first robot on the alliance
   card_robot2       Card // The card for the second robot on the alliance
   card_robot3       Card // The card for the third robot on the alliance
-  zone_bunnies      Int // The number of bunnies in the alliance's low zone at the end of the match
-  zone_balloons_own Int // The number of own balloons in the alliance's low zone at the end of the match
-  zone_balloons_opp Int // The number of opponent ballons in the alliance's low zone at the end of the match
+  
+  feeding_station_auto      Int // The number of carrots in the feeding station at the end of auto
+  feeding_station_tele      Int // The number of carrots in the feeding station at the end of the match (this includes carrots placed during auto)
+  grass_auto                Int // The number of carrots in the grass at the end of auto
+  grass_tele                Int // The number of carrots in the grass at the end of the match (this includes carrots placed during auto)
+  endgame_bunnies           Int // The number of bunnies in the petting zoo at the end of the match
+
+  total_hits                Int // The number of carrots that successfully hit opponent robots
+
+  auto_park_robot1       Boolean // Whether the first robot ends auto partially inside the carrot patch
+  auto_park_robot2       Boolean // Whether the second robot ends auto partially inside the carrot patch
+  auto_park_robot3       Boolean // Whether the third robot ends auto partially inside the carrot patch
+
   foul_points       Int // The number a points an alliance earns from fouls
 }
 

--- a/server/managers/teammanager.ts
+++ b/server/managers/teammanager.ts
@@ -69,7 +69,7 @@ export async function getMatchStats(): Promise<{
             }
 
             stats[team].avg_score += scores.redScore
-            stats[team].avg_coop += match.scores.corral_empty ? 1 : 0
+            stats[team].avg_coop += match.scores.cabbages_in_patch ? 1 : 0
         })
         getBlueAlliance(match).forEach(({ team, card }) => {
             if (team == 0) return
@@ -91,7 +91,7 @@ export async function getMatchStats(): Promise<{
                 stats[team].dq++
             }
             stats[team].avg_score += scores.blueScore
-            stats[team].avg_coop += match.scores.corral_empty ? 1 : 0
+            stats[team].avg_coop += match.scores.cabbages_in_patch ? 1 : 0
         })
     })
 

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -161,7 +161,6 @@ async function setupSocket(socket: Socket<ClientToServerEvents, ServerToClientEv
         io.emit('match', match)
     })
 
-    
     socket.on('partialTeam', async (data: PartialTeam) => {
         logger.debug('receiving team', data)
         if (!data.id) {

--- a/server/tba/index.ts
+++ b/server/tba/index.ts
@@ -215,9 +215,9 @@ function matchToTBAMatch(match: Match): TbaMatch | null {
         const totalPoints = sumBreakdownPoints(points)
         return {
             rp,
-            teleopPoints: points.low_zone_balloon + points.tote_balloons,
-            autoPoints: points.low_zone_bunny,
-            endGameHarmonyPoints: points.empty_corral,
+            teleopPoints: points.tele_bunnies + points.tele_hits + points.tele_carrots,
+            autoPoints: points.auto_carrots + points.auto_park,
+            coopertitionCriteriaMet: points.coopertition > 0,
             totalPoints: totalPoints,
             adjustPoints: points.foul
         }

--- a/server/tba/types.ts
+++ b/server/tba/types.ts
@@ -115,58 +115,40 @@ export interface TbaMatch {
 }
 
 export type TbaScoreBreakdown = {
-    adjustPoints: number
-    autoAmpNoteCount: number
-    autoAmpNotePoints: number
-    autoLeavePoints: number
-    autoLineRobot1: 'Yes' | 'No'
-    autoLineRobot2: 'Yes' | 'No'
-    autoLineRobot3: 'Yes' | 'No'
-    autoPoints: number
-    autoSpeakerNoteCount: number
-    autoSpeakerNotePoints: number
-    autoTotalNotePoints: number
-    coopNotePlayed: boolean
-    coopertitionCriteriaMet: boolean
-    endGameHarmonyPoints: number
-    endGameNoteInTrapPoints: number
-    endGameOnStagePoints: number
-    endGameParkPoints: number
-    endGameRobot1: never //I don't know what the valid values are here and I don't to look
-    endGameRobot2: never
-    endGameRobot3: never
-    endGameSpotLightBonusPoints: number
-    endGameTotalStagePoints: number
-    ensembleBonusAchieved: boolean
-    ensembleBonusOnStageRobotsThreshold: number
-    ensembleBonusStagePointsThreshold: number
-    foulCount: number
-    foulPoints: number
-    g206Penalty: boolean
-    g408Penalty: boolean
-    g424Penalty: boolean
-    melodyBonusAchieved: boolean
-    melodyBonusThreshold: number
-    melodyBonusThresholdCoop: number
-    melodyBonusThresholdNonCoop: number
-    micCenterStage: boolean
-    micStageLeft: boolean
-    micStageRight: boolean
-    rp: number
-    techFoulCount: number
-    teleopAmpNoteCount: number
-    teleopAmpNotePoints: number
-    teleopPoints: number
-    teleopSpeakerNoteAmplifiedCount: number
-    teleopSpeakerNoteAmplifiedPoints: number
-    teleopSpeakerNoteCount: number
-    teleopSpeakerNotePoints: number
-    teleopTotalNotePoints: number
-    totalPoints: number
-    trapCenterStage: boolean
-    trapStageLeft: boolean
-    trapStageRight: boolean
-}
+        "adjustPoints": number,
+      "algaePoints": number,
+      "autoBonusAchieved": boolean,
+      "autoCoralCount": number,
+      "autoCoralPoints": number,
+      "autoLineRobot1": "Yes"|"No",
+      "autoLineRobot2": "Yes"|"No",
+      "autoLineRobot3": "Yes"|"No",
+      "autoMobilityPoints": number,
+      "autoPoints": number,
+      "autoReef": never
+      "bargeBonusAchieved": boolean,
+      "coopertitionCriteriaMet": boolean,
+      "coralBonusAchieved": boolean,
+      "endGameBargePoints": number,
+      "endGameRobot1": never,
+      "endGameRobot2": never,
+      "endGameRobot3": never,
+      "foulCount": number,
+      "foulPoints": number,
+      "g206Penalty": boolean,
+      "g410Penalty": boolean,
+      "g418Penalty": boolean,
+      "g428Penalty": boolean,
+      "netAlgaeCount": number,
+      "rp": number,
+      "techFoulCount": number,
+      "teleopCoralCount": number,
+      "teleopCoralPoints": number,
+      "teleopPoints": number,
+      "teleopReef": never,
+      "totalPoints": number,
+      "wallAlgaeCount": number
+    }
 
 export class TbaAlliance {
     teams: TbaTeamNumber[] = []

--- a/server/tba/types.ts
+++ b/server/tba/types.ts
@@ -115,40 +115,40 @@ export interface TbaMatch {
 }
 
 export type TbaScoreBreakdown = {
-        "adjustPoints": number,
-      "algaePoints": number,
-      "autoBonusAchieved": boolean,
-      "autoCoralCount": number,
-      "autoCoralPoints": number,
-      "autoLineRobot1": "Yes"|"No",
-      "autoLineRobot2": "Yes"|"No",
-      "autoLineRobot3": "Yes"|"No",
-      "autoMobilityPoints": number,
-      "autoPoints": number,
-      "autoReef": never
-      "bargeBonusAchieved": boolean,
-      "coopertitionCriteriaMet": boolean,
-      "coralBonusAchieved": boolean,
-      "endGameBargePoints": number,
-      "endGameRobot1": never,
-      "endGameRobot2": never,
-      "endGameRobot3": never,
-      "foulCount": number,
-      "foulPoints": number,
-      "g206Penalty": boolean,
-      "g410Penalty": boolean,
-      "g418Penalty": boolean,
-      "g428Penalty": boolean,
-      "netAlgaeCount": number,
-      "rp": number,
-      "techFoulCount": number,
-      "teleopCoralCount": number,
-      "teleopCoralPoints": number,
-      "teleopPoints": number,
-      "teleopReef": never,
-      "totalPoints": number,
-      "wallAlgaeCount": number
-    }
+    adjustPoints: number
+    algaePoints: number
+    autoBonusAchieved: boolean
+    autoCoralCount: number
+    autoCoralPoints: number
+    autoLineRobot1: 'Yes' | 'No'
+    autoLineRobot2: 'Yes' | 'No'
+    autoLineRobot3: 'Yes' | 'No'
+    autoMobilityPoints: number
+    autoPoints: number
+    autoReef: never
+    bargeBonusAchieved: boolean
+    coopertitionCriteriaMet: boolean
+    coralBonusAchieved: boolean
+    endGameBargePoints: number
+    endGameRobot1: never
+    endGameRobot2: never
+    endGameRobot3: never
+    foulCount: number
+    foulPoints: number
+    g206Penalty: boolean
+    g410Penalty: boolean
+    g418Penalty: boolean
+    g428Penalty: boolean
+    netAlgaeCount: number
+    rp: number
+    techFoulCount: number
+    teleopCoralCount: number
+    teleopCoralPoints: number
+    teleopPoints: number
+    teleopReef: never
+    totalPoints: number
+    wallAlgaeCount: number
+}
 
 export class TbaAlliance {
     teams: TbaTeamNumber[] = []


### PR DESCRIPTION
- It is expected that the frontend build fails here, I have not updated the frontend to use the new scoring keys
- This updates the prisma schema, TBA, and scoring utility functions

Someone should check that these calculations match the game manual

https://github.com/flamingchickens1540/fowlfield/blob/f1fcb155805dd1f6357ede6f4be5250f452607cf/common/utils/scores.ts#L37-L54